### PR TITLE
doc how to avoid undefined symbol of PCRE issue without uninstall existing PCRE packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VSQL ?= /opt/vertica/bin/vsql
 LOADER_DEBUG = 0
 TARGET ?= ./lib
 
-ALL_CXXFLAGS := $(CXXFLAGS) -I $(SDK_HOME)/include -I $(SDK_HOME)/examples/HelperLibraries -fPIC -shared -Wall -g -std=c++11 -lpcrecpp -lpcre -D_GLIBCXX_USE_CXX11_ABI=0
+ALL_CXXFLAGS := $(CXXFLAGS) -I $(SDK_HOME)/include -I $(SDK_HOME)/examples/HelperLibraries -fPIC -shared -Wall -g -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0
 ALL_CXXFLAGS += -DLOADER_DEBUG=$(LOADER_DEBUG)
 
 build: $(TARGET)/ODBCLoader.so
@@ -56,4 +56,4 @@ test:
 ## Actual build target
 $(TARGET)/ODBCLoader.so: ODBCLoader.cpp $(SDK_HOME)/include/Vertica.cpp $(SDK_HOME)/include/BuildInfo.h
 	mkdir -p $(TARGET)
-	$(CXX) $(ALL_CXXFLAGS) -o $@ $(SDK_HOME)/include/Vertica.cpp ODBCLoader.cpp -lodbc
+	$(CXX) $(ALL_CXXFLAGS) -o $@ $(SDK_HOME)/include/Vertica.cpp ODBCLoader.cpp -lodbc -lpcrecpp -lpcre

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SDK_HOME ?= /opt/vertica/sdk
 SHELL = /bin/bash
 VSQL ?= /opt/vertica/bin/vsql
 LOADER_DEBUG = 0
-TARGET ?= /opt/vertica/packages/odbc-loader/lib
+TARGET ?= ./lib
 
 ALL_CXXFLAGS := $(CXXFLAGS) -I $(SDK_HOME)/include -I $(SDK_HOME)/examples/HelperLibraries -fPIC -shared -Wall -g -std=c++11 -lpcrecpp -lpcre -D_GLIBCXX_USE_CXX11_ABI=0
 ALL_CXXFLAGS += -DLOADER_DEBUG=$(LOADER_DEBUG)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ COPY myschema.myverticatable
 ;
 ```
 where ``rowset`` is an optional parameter to define the number of rows fetched from the remote database in each SQLFetch() call (default = 100). Increasing this parameter can improve the performance but will also increase memory usage.
- 
+
 This will cause Vertica to connect to the remote database identified by the given "connect" string and execute the given query.  It will then fetch the results of the query and load them into the table ``myschema.myverticatable``.
 
 ``myverticatable`` must have the same number of columns as ``remote_table``.  The column types must also match up, or the ODBC driver for the remote database must be able to cast the column types to the Vertica types.  If necessary, you can always explicitly cast on the remote side by modifying the query, or on the local side with a Vertica COPY expression.
@@ -184,10 +184,11 @@ The following error has been reported, during the deloyment phase, on a few Linu
 undefined symbol: _ZNK7pcrecpp2RE13GlobalReplaceERKNS_11StringPieceEPSs
 ```
 
-To fix this issue you might want to...
+#### To fix this issue you might want to...
 
 **STEP 1: get rid of the standard pcre packages**:
 Remove ``pcre-devel`` and ``pcre-cpp`` packages (if installed) using the appropriate package management commands. For example:
+
 ```
 # yum remove pcre-devel pcre-cpp
 ```
@@ -203,6 +204,30 @@ Remove ``pcre-devel`` and ``pcre-cpp`` packages (if installed) using the appropr
 **STEP 3: update you ld.so config and recreate its cache**:
 ```
 # echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && rm /etc/ld.so.cache && ldconfig
+```
+
+#### But if existing version PCRE must be kept, you could...
+
+**STEP 1:  install PCRE from sources to a dedicated location**:
+```
+# tar xzvf pcre-8.45.tar.gz
+# cd pcre-8.45
+# ./configure CXXFLAGS='-std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0' --prefix=/opt/pcre
+# make && make install
+```
+
+**STEP 2: set PATHs for PCRE header files and libraries**:
+```
+echo 'export LD_LIBRARY_PATH=/opt/pcre/lib:${LD_LIBRARY_PATH}' >> /home/dbadmin/.bashrc
+
+export CPLUS_INCLUDE_PATH=/opt/pcre/include:${CPLUS_INCLUDE_PATH}
+export LIBRARY_PATH=/opt/pcre/lib:${LIBRARY_PATH}
+export LD_LIBRARY_PATH=/opt/pcre/lib:${LD_LIBRARY_PATH}
+
+# restart vertica database to effect settings
+admintools -t stop_db -d testdb; admintools -t start_db -d testdb
+
+# Building and installing the library as mentioned before
 ```
 
 ## Sample ODBC Configurations

--- a/ddl/install.sql
+++ b/ddl/install.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE LIBRARY ODBCLoaderLib AS '/opt/vertica/packages/odbc-loader/lib/ODBCLoader.so';
+\set libfile '\''`pwd`'/lib/ODBCLoader.so\'';
+CREATE OR REPLACE LIBRARY ODBCLoaderLib AS :libfile;
 CREATE OR REPLACE PARSER ODBCLoader AS LANGUAGE 'C++' NAME 'ODBCLoaderFactory' LIBRARY ODBCLoaderLib FENCED;
 CREATE OR REPLACE SOURCE ODBCSource AS LANGUAGE 'C++' NAME 'ODBCSourceFactory' LIBRARY ODBCLoaderLib FENCED;
 --CREATE OR REPLACE PARSER ODBCLoader AS LANGUAGE 'C++' NAME 'ODBCLoaderFactory' LIBRARY ODBCLoaderLib NOT FENCED;


### PR DESCRIPTION
An environment has high version PCRE, uninstall them will fail the operation system.
This PR give a way to let multiple version of PCRE coexist.