### PR TITLE
24_1 CI updates - Work in Progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         docker cp ${{ github.workspace }} vertica_docker:/var/odbc-loader
         docker exec -u root vertica_docker /bin/bash -c "sudo chown -R dbadmin:verticadba /var/odbc-loader"
         docker exec -u root -w /var/odbc-loader vertica_docker dnf install -y make
-        docker exec -u dbadmin -w /var/odbc-loader vertica_docker scl enable gcc-toolset-9 "bash -c 'make; make install'"
+        docker exec -u dbadmin -w /var/odbc-loader vertica_docker scl enable gcc-toolset-9 "bash -c 'make CXXFLAGS=\"-D_GLIBCXX_USE_CXX11_ABI=1\"; make install'"
 
     - name: Install ODBC clients
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         docker exec -u root vertica_docker yum -y install pcre-devel
         docker cp ${{ github.workspace }} vertica_docker:/var/odbc-loader
         docker exec -u dbadmin vertica_docker /bin/bash -c "sudo chown -R dbadmin:verticadba /var/odbc-loader"
-        docker exec -w /var/odbc-loader -u dbadmin vertica_docker /bin/bash -c "source /opt/rh/devtoolset-7/enable; \
+        docker exec -w /var/odbc-loader -u dbadmin vertica_docker /bin/bash -c "source /opt/rh/devtoolset-7/enable"; \
         make; \
         make install"
     - name: Install ODBC clients

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         docker exec -u root vertica_docker yum -y install pcre-devel
         docker cp ${{ github.workspace }} vertica_docker:/var/odbc-loader
         docker exec -u dbadmin vertica_docker /bin/bash -c "sudo chown -R dbadmin:verticadba /var/odbc-loader"
-        docker exec -w /var/odbc-loader -u dbadmin vertica_docker /bin/bash -c "source /opt/rh/devtoolset-7/enable"; \
+        docker exec -w /var/odbc-loader -u dbadmin vertica_docker /bin/bash -c "source /opt/rh/devtoolset-7/enable; \
         make; \
         make install"
     - name: Install ODBC clients

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
 
     - name: Install ODBC clients
       run: |
-        docker exec -u root vertica_docker dnf install -y mysql-connector-odbc
+        docker exec -w /var/odbc-loader -u root vertica_docker wget https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-8.2.0-1.el7.src.rpm
+        docker exec -w /var/odbc-loader -u root vertica_docker rpm -i mysql-connector-odbc-8.2.0-1.el7.src.rpm
 
     - name: Run Tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           sleep 1; \
         done;
         docker exec -u root test-mysql mysql -u root -e "CREATE DATABASE testdb;"
-        docker exec -u root -t test-mysql mysql -u root testdb -e "CREATE TABLE test_source (i integer, b boolean, f float, v varchar(32), c char(32), lv varchar(9999), bn binary(32), vb varbinary(32), lvb varbinary(9999), d date, t time, ts timestamp null, tz varchar(80), tsz varchar(80), n numeric(20,4));"
+        docker exec -u root test-mysql mysql -u root testdb -e "CREATE TABLE test_source (i integer, b boolean, f float, v varchar(32), c char(32), lv varchar(9999), bn binary(32), vb varbinary(32), lvb varbinary(9999), d date, t time, ts timestamp null, tz varchar(80), tsz varchar(80), n numeric(20,4));"
         docker exec -u root test-mysql /bin/bash -c "(echo \"INSERT INTO test_source VALUES (null, null, null, null, null, null, null, null, null, null, null, null, null, null, null);\"; for i in \`seq 1 9\`; do echo \"INSERT INTO test_source VALUES (\$i, 1, \$i.5, 'test \$i', 'test \$i', 'test \$i', 'test \$i', 'test \$i', 'test \$i', '\$((\$i+11))00/1/\$i', '4:0\$i', '2038-01-0\$i 03:14:07', '1:2\$i:00', 'June 1, \$((\$i+11))00 03:2\$i EST', '123456.7890');\"; done) | mysql -u root testdb"
         docker exec -u root test-mysql mysql -u root testdb -e "select * from test_source;"
     - name: Set up a Vertica server
@@ -34,7 +34,7 @@ jobs:
           -e ODBCSYSINI=/var/odbc-loader/tests/config \
           --add-host=host.docker.internal:host-gateway \
           --name vertica_docker \
-          vertica/vertica-ce:23.4.0-0
+          vertica/vertica-ce:24.1.0-0
         echo "Vertica startup ..."
         until docker exec vertica_docker test -f /data/vertica/VMart/agent_start.out; do \
           echo "..."; \
@@ -45,19 +45,19 @@ jobs:
         docker exec -u dbadmin vertica_docker /opt/vertica/bin/vsql -c "select version()"
     - name: Build & Install UDx
       run: |
-        docker exec -u root vertica_docker yum -y install centos-release-scl
-        docker exec -u root vertica_docker yum -y install devtoolset-7
-        docker exec -u root vertica_docker yum -y install unixODBC-devel
-        docker exec -u root vertica_docker yum -y install pcre-devel
+        docker exec -u root vertica_docker dnf -y install gcc-toolset-9-gcc-c++.x86_64 
+        docker exec -u root vertica_docker dnf -y install unixODBC-devel
+        docker exec -u root vertica_docker dnf -y install pcre-devel
+        docker exec -u root vertica_docker dnf -y install perl
         docker cp ${{ github.workspace }} vertica_docker:/var/odbc-loader
-        docker exec -u dbadmin vertica_docker /bin/bash -c "sudo chown -R dbadmin:verticadba /var/odbc-loader"
-        docker exec -w /var/odbc-loader -u dbadmin vertica_docker /bin/bash -c "source /opt/rh/devtoolset-7/enable; \
-        make; \
-        make install"
+        docker exec -u root vertica_docker /bin/bash -c "sudo chown -R dbadmin:verticadba /var/odbc-loader"
+        docker exec -u root -w /var/odbc-loader vertica_docker dnf install -y make
+        docker exec -u dbadmin -w /var/odbc-loader vertica_docker scl enable gcc-toolset-9 "bash -c 'make; make install'"
+
     - name: Install ODBC clients
       run: |
-        docker exec -w /var/odbc-loader -u root vertica_docker wget https://downloads.mysql.com/archives/get/p/10/file/https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-8.2.0-1.el7.src.rpm
-        docker exec -w /var/odbc-loader -u root vertica_docker rpm -i https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-8.2.0-1.el7.src.rpm
+        docker exec -u root vertica_docker dnf install -y mysql-connector-odbc
+
     - name: Run Tests
       run: |
         docker exec -w /var/odbc-loader -u dbadmin vertica_docker make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,8 @@ jobs:
         make install"
     - name: Install ODBC clients
       run: |
-        docker exec -w /var/odbc-loader -u root vertica_docker wget https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-8.0.31-1.el7.x86_64.rpm
-        docker exec -w /var/odbc-loader -u root vertica_docker rpm -i mysql-connector-odbc-8.0.31-1.el7.x86_64.rpm
+        docker exec -w /var/odbc-loader -u root vertica_docker wget https://downloads.mysql.com/archives/get/p/10/file/https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-8.2.0-1.el7.src.rpm
+        docker exec -w /var/odbc-loader -u root vertica_docker rpm -i https://downloads.mysql.com/archives/get/p/10/file/mysql-connector-odbc-8.2.0-1.el7.src.rpm
     - name: Run Tests
       run: |
         docker exec -w /var/odbc-loader -u dbadmin vertica_docker make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         docker cp ${{ github.workspace }} vertica_docker:/var/odbc-loader
         docker exec -u root vertica_docker /bin/bash -c "sudo chown -R dbadmin:verticadba /var/odbc-loader"
         docker exec -u root -w /var/odbc-loader vertica_docker dnf install -y make
-        docker exec -u dbadmin -w /var/odbc-loader vertica_docker scl enable gcc-toolset-9 "bash -c 'make CXXFLAGS=\"-D_GLIBCXX_USE_CXX11_ABI=1\"; make install'"
+        docker exec -u dbadmin -w /var/odbc-loader vertica_docker scl enable gcc-toolset-9 "bash -c 'make; make install'"
 
     - name: Install ODBC clients
       run: |

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ VSQL ?= /opt/vertica/bin/vsql
 LOADER_DEBUG = 0
 TARGET ?= ./lib
 
-ALL_CXXFLAGS := $(CXXFLAGS) -I $(SDK_HOME)/include -I $(SDK_HOME)/examples/HelperLibraries -fPIC -shared -Wall -g -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0
+ALL_CXXFLAGS := $(CXXFLAGS) -I $(SDK_HOME)/include -I $(SDK_HOME)/examples/HelperLibraries -fPIC -shared -Wall -g -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=1
 ALL_CXXFLAGS += -DLOADER_DEBUG=$(LOADER_DEBUG)
 
 build: $(TARGET)/ODBCLoader.so


### PR DESCRIPTION
The 24.1 Vertica CE image is an Alma8 based image. There are changes needed to be made to the CI.yml file in order to support the same functionality on this new image. This has required updates to the packages installed as well as the package manager used. It requires a mysql odbc connector update. 

At this point this PR has accomplished updates for the build steps
1) Set up MySQL server
2) Set up a Vertica server
3) Build & Install UDx

What doesn't seem to be working yet are the build steps:
4) Install ODBC clients
5) Run Tests

I don't believe any changes need to be made to step 5 to get it to work other than successfully accomplishing step 4. I believe the version of the mysql connector is now updated to the version that we need. I am successfully downloading the rpm. But something in the installation isn't happening or happening properly so when we go to test, we can't find the shared library file for connecting mysql with the odbc interface (libmyodbc8w.so)