### PR TITLE
Fix plain COPY crash and restore copy_test to test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,21 @@ test:
 	@echo "Running ODBCLoader Test Suite"
 	@echo "========================================="
 	@echo ""
+	@echo "[*] Running Copy Test..."
+	@echo ""
+	@$(VSQL) -f tests/copy_test.sql 2>&1 | tee $(TMPDIR)/copy_test.out | perl -pe 's/^vsql:[\/_:\w\.]* /vsql: /; \
+	              s/\[ODBC[^\]]*\]/[...]/g; \
+		      s/\[mysql[^\]]*\]/[...]/g; \
+		      s/(Error parsing .* )\(.*\)$$/$$1(...)/; \
+		      s/mariadb/MySQL/ig; '
+	@echo ""
+	@echo "[*] Validating copy test output..."
+	@diff -u tests/expected/copy_test.out <(perl -pe 's/^vsql:[\/_:\w\.]* /vsql: /; \
+	              s/\[ODBC[^\]]*\]/[...]/g; \
+		      s/\[mysql[^\]]*\]/[...]/g; \
+		      s/(Error parsing .* )\(.*\)$$/$$1(...)/; \
+		      s/mariadb/MySQL/ig; ' $(TMPDIR)/copy_test.out) && echo "[✓] Copy test validation passed" || (echo "[✗] Copy test validation failed" && exit 1)
+	@echo ""
 	@echo "[*] Running Federated Queries Test..."
 	@echo ""
 	@$(VSQL) -f tests/federated_queries.sql 2>&1 | tee $(TMPDIR)/federated_queries.out | perl -pe 's/^vsql:[\/_:\w\.]* /vsql: /; \

--- a/ODBCLoader.cpp
+++ b/ODBCLoader.cpp
@@ -574,10 +574,11 @@ public:
 
         // Check "hidden" parameters __query_col_name__ and __query_col_idx__ to filter out columns
         if ( src_cfilter ) {
-           if (srvInterface.getParamReader().containsParameter("__query_col_name__") &&
-               !srvInterface.getParamReader().getStringRef("__query_col_name__").str().empty()) {
-               if (srvInterface.getParamReader().containsParameter("__query_col_idx__")) {
-                   colInTable = (int)colInfo.getColumnCount() ;
+            // Only column-filter when the param is actually non-empty, a plain COPY sends it empty.
+            if (srvInterface.getParamReader().containsParameter("__query_col_name__") &&
+                !srvInterface.getParamReader().getStringRef("__query_col_name__").str().empty()) {
+                if (srvInterface.getParamReader().containsParameter("__query_col_idx__")) {
+                    colInTable = (int)colInfo.getColumnCount() ;
 #if LOADER_DEBUG
  srvInterface.log("DEBUG __query_col_name__=<%s>",srvInterface.getParamReader().getStringRef("__query_col_name__").str().c_str());
  srvInterface.log("DEBUG __query_col_idx__=<%s>",srvInterface.getParamReader().getStringRef("__query_col_idx__").str().c_str());

--- a/ODBCLoader.cpp
+++ b/ODBCLoader.cpp
@@ -574,9 +574,10 @@ public:
 
         // Check "hidden" parameters __query_col_name__ and __query_col_idx__ to filter out columns
         if ( src_cfilter ) {
-           if (srvInterface.getParamReader().containsParameter("__query_col_name__")) {
+           if (srvInterface.getParamReader().containsParameter("__query_col_name__") &&
+               !srvInterface.getParamReader().getStringRef("__query_col_name__").str().empty()) {
                if (srvInterface.getParamReader().containsParameter("__query_col_idx__")) {
-                   colInTable = (int)colInfo.getColumnCount() ; 
+                   colInTable = (int)colInfo.getColumnCount() ;
 #if LOADER_DEBUG
  srvInterface.log("DEBUG __query_col_name__=<%s>",srvInterface.getParamReader().getStringRef("__query_col_name__").str().c_str());
  srvInterface.log("DEBUG __query_col_idx__=<%s>",srvInterface.getParamReader().getStringRef("__query_col_idx__").str().c_str());
@@ -603,6 +604,9 @@ srvInterface.log("-----> External Table Columns, colInTable=<%d>", colInTable);
                            query  +
                            " ) sq" ;
                }
+            } else {
+                // Plain COPY: column-filter param present but empty -> load all columns.
+                query = "SELECT * FROM ( " + query + " ) sq" ;
             }
 
         } else {
@@ -664,6 +668,14 @@ srvInterface.log("-----> External Table Columns, colInTable=<%d>", colInTable);
         // Allocate space for Vertica data types OID and size
         vtype = (BaseDataOID *)srvInterface.allocator->alloc(numcols * sizeof(BaseDataOID)) ;
         stype = (uint32 *)srvInterface.allocator->alloc(numcols * sizeof(uint32)) ;
+
+        // Plain COPY path leaves vidx empty (no column filtering). Default it to
+        // identity mapping (0..numcols-1) so vidx.at(i) below is valid.
+        if (vidx.empty()) {
+            for (SQLSMALLINT i = 0; i < numcols; i++) {
+                vidx.push_back(i);
+            }
+        }
 
         // Set up column-data buffers
         // Bind to the columns in question

--- a/ODBCLoader.cpp
+++ b/ODBCLoader.cpp
@@ -669,12 +669,13 @@ srvInterface.log("-----> External Table Columns, colInTable=<%d>", colInTable);
         vtype = (BaseDataOID *)srvInterface.allocator->alloc(numcols * sizeof(BaseDataOID)) ;
         stype = (uint32 *)srvInterface.allocator->alloc(numcols * sizeof(uint32)) ;
 
-        // Plain COPY path leaves vidx empty (no column filtering). Default it to
-        // identity mapping (0..numcols-1) so vidx.at(i) below is valid.
+        // Plain COPY leaves vidx empty. Default to identity mapping and set
+        // colInTable so the pre-null loop covers all columns.
         if (vidx.empty()) {
             for (SQLSMALLINT i = 0; i < numcols; i++) {
                 vidx.push_back(i);
             }
+            colInTable = numcols;
         }
 
         // Set up column-data buffers

--- a/tests/expected/copy_test.out
+++ b/tests/expected/copy_test.out
@@ -1,5 +1,3 @@
-Timing is on.
-Pager usage is off.
 Timing is off.
 SET
 CREATE TABLE


### PR DESCRIPTION
**Issue-**
Running a plain COPY with the ODBC loader was failing with ERROR 3399: InvokeSetupUDL(): UDx side process has exited abnormally. The external table path worked fine, only plain COPY crashed.

**Root Cause-**
I traced it back to commit eae4c95 (#19), which added column pruning. That change made the code use vidx.at(i) to map columns, and vidx only gets filled when the hidden column-filter params (__query_col_name__ / __query_col_idx__) are sent.
On a plain COPY those params are sent but empty. Two things went wrong because of that:
1. The code still entered the column-filter block and built a broken query like SELECT  FROM (...) (empty column list), which the remote DB rejected.
2. vidx stayed empty, so vidx.at(i) later threw an out-of-range and killed the process.

**Fix-**
- Only do column filtering when the column-name param is actually non-empty. If it's empty (plain COPY), build SELECT * FROM (...) and load all columns.
- If vidx is empty when we bind columns, default it to a straight 0..numcols-1 mapping, and set colInTable so the pre-null loop covers all columns. This keeps the plain COPY path behaving like it did before the change, so all columns line up correctly.

**Testing-**
- Tested a plain COPY against our source and it now loads all rows correctly (verified row count and data).
- Also restored copy_test in the Makefile test target.

<img width="1572" height="505" alt="image" src="https://github.com/user-attachments/assets/a1a3f726-5379-4b2f-ac22-0dfaaeb88509" />
